### PR TITLE
Remove potential secrets

### DIFF
--- a/apis/v1/cloudconnections/api/openapi.yaml
+++ b/apis/v1/cloudconnections/api/openapi.yaml
@@ -157,8 +157,8 @@ paths:
                   description: Description for this AWS access key connection
                   type: aws
                   details:
-                    accessKeyId: AKBATYTCJY7XPKGABY5L
-                    secretAccessKey: 7ccw68gBKMMXUdXBut+7qC9CCr1brotxD5ClcGGE
+                    accessKeyId: ABCDEFGHIJKLMNOPQRST
+                    secretAccessKey: abcdefghijklmnopqrstuvwxyz1234567890abcd
                     accessType: access_key
               Create connection for AWS access key with assigned configurationId and set state to ACTIVE:
                 value:
@@ -167,8 +167,8 @@ paths:
                     assigned configurationId
                   type: aws
                   details:
-                    accessKeyId: AKBATYTCJY7XPKGABY5L
-                    secretAccessKey: 7ccw68gBKMMXUdXBut+7qC9CCr1brotxD5ClcGGE
+                    accessKeyId: ABCDEFGHIJKLMNOPQRST
+                    secretAccessKey: abcdefghijklmnopqrstuvwxyz1234567890abcd
                     accessType: access_key
                   configurationId: fd7bb1bd-f605-4eac-9ec9-32b7031d4576
                   state: ACTIVE
@@ -962,10 +962,10 @@ components:
     AzureBaseDetails:
       properties:
         clientId:
-          example: 17760330-4ecd-47d5-818b-40308d3e67d1
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         clientSecret:
-          example: k33C_.5b0VrXSiQIf1t-c--p18~Ea_L~2H
+          example: abcdefghijklmnopqrstuvwxyz
           format: password
           type: string
       required:
@@ -1318,7 +1318,7 @@ components:
             \ or account root user. The access key ID is one of two access keys needed\
             \ to authenticate to AWS. The other is a secret access key. You need access\
             \ keys to make programmatic calls using the AWS CLI, AWS Tools, or PowerShell."
-          example: AKBATYTCJY7XPKGABY5L
+          example: ABCDEFGHIJKLMNOPQRST
           type: string
         secretAccessKey:
           description: "The secret access key is one of two access keys needed to\
@@ -1327,7 +1327,7 @@ components:
             \ secret access key and save in a secure location. If the secret access\
             \ key is lost or deleted, you must create a new one. You need access keys\
             \ to make programmatic calls using the AWS CLI, AWS Tools, or PowerShell."
-          example: 7ccw68gBKMMXUdXBut+7qC9CCr1brotxD5ClcGGE
+          example: abcdefghijklmnopqrstuvwxyz1234567890abcd
           format: password
           type: string
       required:
@@ -1342,21 +1342,21 @@ components:
             \ for an Azure user, or account root user. The Client ID is one of three\
             \ properties needed to authenticate to Azure, the other two being Client\
             \ Secret and Tenant (Directory) ID"
-          example: 17760330-4ecd-47d5-818b-40308d3e67d1
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         clientSecret:
           description: "A Client Secret allows an Azure application to provide its\
             \ identity when requesting an access token. The Client Secret is one of\
             \ three properties needed to authenticate to Azure, the other two being\
             \ Client ID (Application ID) and Tenant (Directory) ID"
-          example: k33C_.5b0VrXSiQIf1t-c--p18~Ea_L~2H
+          example: abcdefghijklmnopqrstuvwxyz
           format: password
           type: string
         tenantId:
           description: The Azure AD Tenant (Directory) IDis one of three properties
             needed to authenticate to Azure. The other two are Client Secret and Client
             ID (Application ID).
-          example: 5ae1af62-9505-4097-a69a-c1553ef7840e
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         subscriptionId:
           description: "Specify a GUID Subscription ID to monitor. If monitoring all\
@@ -1435,10 +1435,10 @@ components:
     ConnectionUpdate_details_oneOf_1:
       properties:
         accessKeyId:
-          example: AKBATYTCJY7XPKGABY5L
+          example: ABCDEFGHIJKLMNOPQRST
           type: string
         secretAccessKey:
-          example: 7ccw68gBKMMXUdXBut+7qC9CCr1brotxD5ClcGGE
+          example: abcdefghijklmnopqrstuvwxyz1234567890abcd
           format: password
           type: string
       required:
@@ -1448,10 +1448,10 @@ components:
     ConnectionUpdate_details_oneOf_2:
       properties:
         clientId:
-          example: 17760330-4ecd-47d5-818b-40308d3e67d1
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         clientSecret:
-          example: k33C_.5b0VrXSiQIf1t-c--p18~Ea_L~2H
+          example: abcdefghijklmnopqrstuvwxyz
           format: password
           type: string
       required:

--- a/apis/v1/cloudconnections/docs/ConnectionsApi.md
+++ b/apis/v1/cloudconnections/docs/ConnectionsApi.md
@@ -33,7 +33,7 @@ import (
 )
 
 func main() {
-    connectionRequest := *openapiclient.NewConnectionRequest(openapiclient.ConnectionRequestDetails{AWSConnectionRequestDetails: penapiclient.AWSConnectionRequestDetails{AWSAccessKeyDetails: openapiclient.NewAWSAccessKeyDetails("AKBATYTCJY7XPKGABY5L", "7ccw68gBKMMXUdXBut+7qC9CCr1brotxD5ClcGGE", openapiclient.ConnectionAccessType("role_delegation"))}}, "AWS dev", openapiclient.ProviderType("aws")) // ConnectionRequest | 
+    connectionRequest := *openapiclient.NewConnectionRequest(openapiclient.ConnectionRequestDetails{AWSConnectionRequestDetails: penapiclient.AWSConnectionRequestDetails{AWSAccessKeyDetails: openapiclient.NewAWSAccessKeyDetails("ABCDEFGHIJKLMNOPQRST", "abcdefghijklmnopqrstuvwxyz1234567890abcd", openapiclient.ConnectionAccessType("role_delegation"))}}, "AWS dev", openapiclient.ProviderType("aws")) // ConnectionRequest | 
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)


### PR DESCRIPTION
## Description

AWS and Azure secrets present in the example section of OpenAPI document looks real. It is possible that they were valid at one point. I have ensured that these secrets are no longer valid using `aws` and `azure` CLI. Removed the secrets from files.

### AWS Secrets
```
$ grep cisco-open -A 3 ~/.aws/credentials
[cisco-open]
aws_access_key_id=AKBATYTCJY7XPKGABY5L
aws_secret_access_key=7ccw68gBKMMXUdXBut+7qC9CCr1brotxD5ClcGGE

$ AWS_PROFILE=cisco-open aws sts get-caller-identity

An error occurred (InvalidClientTokenId) when calling the GetCallerIdentity operation: The security token included in the request is invalid. 
```

### Azure Secrets
```
$ az login --service-principal -u 17760330-4ecd-47d5-818b-40308d3e67d1 -p 'k33C_.5b0VrXSiQIf1t-c--p18~Ea_L~2H' --tenant 5ae1af62-9505-4097-a69a-c1553ef7840e
AADSTS7000222: The provided client secret keys for app '17760330-4ecd-47d5-818b-40308d3e67d1' are expired. Visit the Azure portal to create new keys for your app: https://aka.ms/NewClientSecret, or consider using certificate credentials for added security: https://aka.ms/certCreds. Trace ID: 6266fbf7-b523-4687-bc60-ce5a8f09b900 Correlation ID: e5e3d55f-e493-4279-a520-e95a059d4217 Timestamp: 2024-05-30 21:02:42Z
Interactive authentication is needed. Please run:
az login 
```

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (Fix a security concern)

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
